### PR TITLE
SM-202: Implement plugins for all available read/write streams

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.bat]
+end_of_line = crlf
+
+[composer.json]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Define the line ending behavior of the different file extensions
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text text=auto eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary
+*.jpeg binary
+*.zip binary
+*.phar binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+*.eot binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.xsd binary
+*.ts binary
+*.exe binary
+
+# Remove files for archives generated using `git archive`
+codeception.yml export-ignore
+dependency.json export-ignore
+phpstan.json export-ignore
+phpstan.neon export-ignore
+tooling.yml export-ignore
+.coveralls.yml export-ignore
+.travis.yml export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
     environment:
-        php: '7.1'
+        php: '7.2'
 
     nodes:
         analysis:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 matrix:
   fast_finish: true
   include:
-  - php: "7.1"
+  - php: "7.2"
 
 services:
 - postgresql

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Process Module
 
 [![Build Status](https://travis-ci.org/spryker-middleware/process.svg?branch=master)](https://travis-ci.org/spryker-middleware/process)
-[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%207.1-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.2-8892BF.svg)](https://php.net/)
 [![License](https://poser.pugx.org/spryker-middleware/process/license.svg)](https://packagist.org/packages/spryker-middleware/process)
 [![Total Downloads](https://poser.pugx.org/spryker-middleware/process/d/total.svg)](https://packagist.org/packages/spryker-middleware/process)
 

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "proprietary",
     "minimum-stability": "dev",
     "require": {
+        "monolog/monolog": "^2.0.0",
         "php": ">=7.1",
         "spryker/symfony": "^3.0.0",
         "spryker/console": "^4.0.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "monolog/monolog": "^2.0.0",
-        "php": ">=7.2",
+        "php": ">=7.1",
         "spryker/symfony": "^3.0.0",
         "spryker/console": "^4.0.0",
         "spryker/development": "^3.0.0",
@@ -33,6 +33,11 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "process-timeout": 600
+    },
+   "extra": {
+        "branch-alias": {
+          "dev-master": "1.0.x-dev"
+        }
     },
     "scripts": {
         "cs-check": "phpcs --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml -v src/ tests/",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "monolog/monolog": "^2.0.0",
-        "php": ">=7.1",
+        "php": ">=7.2",
         "spryker/symfony": "^3.0.0",
         "spryker/console": "^4.0.0",
         "spryker/development": "^3.0.0",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.1",
+        "srpryker/symfony": "^3.0.0",
         "spryker/console": "^4.0.0",
         "spryker/development": "^3.0.0",
         "spryker/transfer": "^3.4.0",

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "require": {
         "monolog/monolog": "^2.0.0",
         "php": ">=7.2",
-        "spryker/symfony": "^3.0.0",
         "spryker/console": "^4.0.0",
         "spryker/development": "^3.0.0",
+        "spryker/symfony": "^3.0.0",
         "spryker/transfer": "^3.4.0",
         "spryker/util-encoding": "^2.0.0",
         "spryker-middleware/logger": "^1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.1",
-        "srpryker/symfony": "^3.0.0",
+        "spryker/symfony": "^3.0.0",
         "spryker/console": "^4.0.0",
         "spryker/development": "^3.0.0",
         "spryker/transfer": "^3.4.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/src/SprykerMiddleware/Shared/Process/Transfer/process.transfer.xml
+++ b/src/SprykerMiddleware/Shared/Process/Transfer/process.transfer.xml
@@ -6,9 +6,9 @@
     <transfer name="ProcessSettings">
         <property name="name" type="string"/>
         <property name="inputPath" type="string"/>
-        <property name="inputStreamOptions" type="array"/>
+        <property name="inputStreamOptions" type="array" singular="inputStreamOption"/>
         <property name="outputPath" type="string"/>
-        <property name="outputStreamOptions" type="array"/>
+        <property name="outputStreamOptions" type="array" singular="outputStreamOption"/>
         <property name="iteratorConfig" type="IteratorConfig"/>
         <property name="loggerConfig" type="LoggerConfig"/>
     </transfer>
@@ -25,16 +25,16 @@
     </transfer>
 
     <transfer name="MapperConfig">
-        <property name="map" type="array"/>
+        <property name="map" type="array" singular="map"/>
         <property name="strategy" type="string"/>
     </transfer>
 
     <transfer name="TranslatorConfig">
-        <property name="dictionary" type="array"/>
+        <property name="dictionary" type="array" singular="dictionary"/>
     </transfer>
 
     <transfer name="ValidatorConfig">
-        <property name="rules" type="array"/>
+        <property name="rules" type="array" singular="rule"/>
     </transfer>
 
     <transfer name="ProcessResult">

--- a/src/SprykerMiddleware/Shared/Process/Transfer/process.transfer.xml
+++ b/src/SprykerMiddleware/Shared/Process/Transfer/process.transfer.xml
@@ -6,7 +6,9 @@
     <transfer name="ProcessSettings">
         <property name="name" type="string"/>
         <property name="inputPath" type="string"/>
+        <property name="inputStreamOptions" type="array"/>
         <property name="outputPath" type="string"/>
+        <property name="outputStreamOptions" type="array"/>
         <property name="iteratorConfig" type="IteratorConfig"/>
         <property name="loggerConfig" type="LoggerConfig"/>
     </transfer>

--- a/src/SprykerMiddleware/Zed/Process/Business/Process/Processor.php
+++ b/src/SprykerMiddleware/Zed/Process/Business/Process/Processor.php
@@ -15,6 +15,7 @@ use SprykerMiddleware\Zed\Process\Business\Exception\TolerableProcessException;
 use SprykerMiddleware\Zed\Process\Business\Pipeline\PipelineInterface;
 use SprykerMiddleware\Zed\Process\Business\PluginResolver\ProcessPluginResolverInterface;
 use SprykerMiddleware\Zed\Process\Business\ProcessResult\ProcessResultHelperInterface;
+use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OptionAwareStreamPluginInterface;
 
 class Processor implements ProcessorInterface
 {
@@ -160,13 +161,17 @@ class Processor implements ProcessorInterface
         $this->processPlugin = $this->processPluginResolver
             ->getProcessConfigurationPluginByProcessName($this->processSettingsTransfer->getName());
 
-        $this->inputStream = $this->processPlugin
-            ->getInputStreamPlugin()
-            ->getInputStream($this->processSettingsTransfer->getInputPath());
+        $inputStreamPlugin = $this->processPlugin->getInputStreamPlugin();
+        if ($inputStreamPlugin instanceof OptionAwareStreamPluginInterface) {
+            $inputStreamPlugin->setOptions($this->processSettingsTransfer->getInputStreamOptions());
+        }
+        $this->inputStream = $inputStreamPlugin->getInputStream($this->processSettingsTransfer->getInputPath());
 
-        $this->outputStream = $this->processPlugin
-            ->getOutputStreamPlugin()
-            ->getOutputStream($this->processSettingsTransfer->getOutputPath());
+        $outputStreamPlugin = $this->processPlugin->getOutputStreamPlugin();
+        if ($outputStreamPlugin instanceof OptionAwareStreamPluginInterface) {
+            $outputStreamPlugin->setOptions($this->processSettingsTransfer->getOutputStreamOptions());
+        }
+        $this->outputStream = $outputStreamPlugin->getOutputStream($this->processSettingsTransfer->getOutputPath());
 
         $this->iterator = $this->processPlugin
             ->getIteratorPlugin()

--- a/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
@@ -95,7 +95,7 @@ class ProcessConsole extends Console
             static::OPTION_INPUT_OPTIONS,
             static::OPTION_INPUT_OPTIONS_SHORTCUT,
             InputOption::VALUE_OPTIONAL,
-            'Input Stream Options',
+            'Input Stream Options. Should be JSON format, for example: \'{"rootNodeName": "Root"}\'',
             static::DEFAULT_OPTIONS
         );
 
@@ -110,7 +110,7 @@ class ProcessConsole extends Console
             static::OPTION_OUTPUT_OPTIONS,
             static::OPTION_OUTPUT_OPTIONS_SHORTCUT,
             InputOption::VALUE_OPTIONAL,
-            'Output Stream Options',
+            'Output Stream Options. Should be JSON format, for example: \'{"rootNodeName": "Root", "entityNodeName": "Entity"}\'',
             static::DEFAULT_OPTIONS
         );
     }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
@@ -260,6 +260,6 @@ class ProcessConsole extends Console
      */
     protected function mapOptionToArray(string $option): ?array
     {
-        return json_decode($option, true);
+        return $this->getFactory()->getUtilEncodingService()->decodeJson($option, true);
     }
 }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
@@ -29,13 +29,20 @@ class ProcessConsole extends Console
     protected const OPTION_ITERATOR_LIMIT = 'limit';
     protected const OPTION_LOG_LEVEL = 'flagLogLevel';
     protected const OPTION_INPUT = 'input';
+    protected const OPTION_INPUT_OPTIONS = 'input-options';
     protected const OPTION_OUTPUT = 'output';
+    protected const OPTION_OUTPUT_OPTIONS = 'output-options';
     protected const OPTION_PROCESS_NAME_SHORTCUT = 'p';
     protected const OPTION_ITERATOR_OFFSET_SHORTCUT = 's';
     protected const OPTION_ITERATOR_LIMIT_SHORTCUT = 'l';
     protected const OPTION_LOG_LEVEL_SHORTCUT = 'f';
     protected const OPTION_INPUT_SHORTCUT = 'i';
     protected const OPTION_OUTPUT_SHORTCUT = 'o';
+    protected const OPTION_INPUT_OPTIONS_SHORTCUT = 't';
+    protected const OPTION_OUTPUT_OPTIONS_SHORTCUT = 'u';
+
+    protected const DEFAULT_OPTIONS = '{}';
+
 
     /**
      * @var int
@@ -86,10 +93,26 @@ class ProcessConsole extends Console
         );
 
         $this->addOption(
+            static::OPTION_INPUT_OPTIONS,
+            static::OPTION_INPUT_OPTIONS_SHORTCUT,
+            InputOption::VALUE_OPTIONAL,
+            'Input Stream Options',
+            static::DEFAULT_OPTIONS
+        );
+
+        $this->addOption(
             static::OPTION_OUTPUT,
             static::OPTION_OUTPUT_SHORTCUT,
             InputOption::VALUE_REQUIRED,
             'Output Stream'
+        );
+
+        $this->addOption(
+            static::OPTION_OUTPUT_OPTIONS,
+            static::OPTION_OUTPUT_OPTIONS_SHORTCUT,
+            InputOption::VALUE_OPTIONAL,
+            'Output Stream Options',
+            static::DEFAULT_OPTIONS
         );
     }
 
@@ -207,5 +230,37 @@ class ProcessConsole extends Console
         }
         $processSettingsTransfer->setInputPath($inputPath);
         $processSettingsTransfer->setOutputPath($outputPath);
+        $processSettingsTransfer->setInputStreamOptions($this->getInputStreamOptions($input));
+        $processSettingsTransfer->setOutputStreamOptions($this->getOutputStreamOptions($input));
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     *
+     * @return array
+     */
+    protected function getInputStreamOptions(InputInterface $input): array
+    {
+        return $this->mapOptionToArray($input->getOption(static::OPTION_INPUT_OPTIONS));
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     *
+     * @return array
+     */
+    protected function getOutputStreamOptions(InputInterface $input): array
+    {
+        return $this->mapOptionToArray($input->getOption(static::OPTION_OUTPUT_OPTIONS));
+    }
+
+    /**
+     * @param string $option
+     *
+     * @return array
+     */
+    protected function mapOptionToArray(string $option): ?array
+    {
+        return json_decode($option, true);
     }
 }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
@@ -260,7 +260,7 @@ class ProcessConsole extends Console
     /**
      * @param string $options
      *
-     * @return array
+     * @return array|null
      */
     protected function mapOptionToArray(string $options): ?array
     {

--- a/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
@@ -43,9 +43,9 @@ class ProcessConsole extends Console
 
     protected const DEFAULT_OPTIONS = '{}';
 
-    protected const OPTION_INPUT_OPTIONS_DESCRIPTION = 'Input Stream Options. Should be JSON format, for example: \'{"rootNodeName": "Root"}\'';
+    protected const OPTION_INPUT_OPTIONS_DESCRIPTION = 'Input Stream Options. Must be JSON format, for example: \'{"rootNodeName": "Root"}\'';
 
-    protected const OPTION_OUTPUT_OPTIONS_DESCRIPTION = 'Output Stream Options. Should be JSON format, for example: \'{"rootNodeName": "Root", "entityNodeName": "Entity"}\'';
+    protected const OPTION_OUTPUT_OPTIONS_DESCRIPTION = 'Output Stream Options. Must be JSON format, for example: \'{"rootNodeName": "Root", "entityNodeName": "Entity"}\'';
 
     /**
      * @var int

--- a/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
@@ -43,7 +43,6 @@ class ProcessConsole extends Console
 
     protected const DEFAULT_OPTIONS = '{}';
 
-
     /**
      * @var int
      */

--- a/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
@@ -43,6 +43,10 @@ class ProcessConsole extends Console
 
     protected const DEFAULT_OPTIONS = '{}';
 
+    protected const OPTION_INPUT_OPTIONS_DESCRIPTION = 'Input Stream Options. Should be JSON format, for example: \'{"rootNodeName": "Root"}\'';
+
+    protected const OPTION_OUTPUT_OPTIONS_DESCRIPTION = 'Output Stream Options. Should be JSON format, for example: \'{"rootNodeName": "Root", "entityNodeName": "Entity"}\'';
+
     /**
      * @var int
      */
@@ -95,7 +99,7 @@ class ProcessConsole extends Console
             static::OPTION_INPUT_OPTIONS,
             static::OPTION_INPUT_OPTIONS_SHORTCUT,
             InputOption::VALUE_OPTIONAL,
-            'Input Stream Options. Should be JSON format, for example: \'{"rootNodeName": "Root"}\'',
+            static::OPTION_INPUT_OPTIONS_DESCRIPTION,
             static::DEFAULT_OPTIONS
         );
 
@@ -110,7 +114,7 @@ class ProcessConsole extends Console
             static::OPTION_OUTPUT_OPTIONS,
             static::OPTION_OUTPUT_OPTIONS_SHORTCUT,
             InputOption::VALUE_OPTIONAL,
-            'Output Stream Options. Should be JSON format, for example: \'{"rootNodeName": "Root", "entityNodeName": "Entity"}\'',
+            static::OPTION_OUTPUT_OPTIONS_DESCRIPTION,
             static::DEFAULT_OPTIONS
         );
     }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Console/ProcessConsole.php
@@ -29,23 +29,23 @@ class ProcessConsole extends Console
     protected const OPTION_ITERATOR_LIMIT = 'limit';
     protected const OPTION_LOG_LEVEL = 'flagLogLevel';
     protected const OPTION_INPUT = 'input';
-    protected const OPTION_INPUT_OPTIONS = 'input-options';
+    protected const OPTION_INPUT_STREAM_OPTIONS = 'input-stream-options';
     protected const OPTION_OUTPUT = 'output';
-    protected const OPTION_OUTPUT_OPTIONS = 'output-options';
+    protected const OPTION_OUTPUT_STREAM_OPTIONS = 'output-stream-options';
     protected const OPTION_PROCESS_NAME_SHORTCUT = 'p';
     protected const OPTION_ITERATOR_OFFSET_SHORTCUT = 's';
     protected const OPTION_ITERATOR_LIMIT_SHORTCUT = 'l';
     protected const OPTION_LOG_LEVEL_SHORTCUT = 'f';
     protected const OPTION_INPUT_SHORTCUT = 'i';
     protected const OPTION_OUTPUT_SHORTCUT = 'o';
-    protected const OPTION_INPUT_OPTIONS_SHORTCUT = 't';
-    protected const OPTION_OUTPUT_OPTIONS_SHORTCUT = 'u';
+    protected const OPTION_INPUT_STREAM_OPTIONS_SHORTCUT = 't';
+    protected const OPTION_OUTPUT_STREAM_OPTIONS_SHORTCUT = 'u';
 
     protected const DEFAULT_OPTIONS = '{}';
 
-    protected const OPTION_INPUT_OPTIONS_DESCRIPTION = 'Input Stream Options. Must be JSON format, for example: \'{"rootNodeName": "Root"}\'';
+    protected const OPTION_INPUT_STREAM_OPTIONS_DESCRIPTION = 'Input Stream Options. Must be JSON format, for example: \'{"rootNodeName": "Root"}\'';
 
-    protected const OPTION_OUTPUT_OPTIONS_DESCRIPTION = 'Output Stream Options. Must be JSON format, for example: \'{"rootNodeName": "Root", "entityNodeName": "Entity"}\'';
+    protected const OPTION_OUTPUT_STREAM_OPTIONS_DESCRIPTION = 'Output Stream Options. Must be JSON format, for example: \'{"rootNodeName": "Root", "entityNodeName": "Entity"}\'';
 
     /**
      * @var int
@@ -96,10 +96,10 @@ class ProcessConsole extends Console
         );
 
         $this->addOption(
-            static::OPTION_INPUT_OPTIONS,
-            static::OPTION_INPUT_OPTIONS_SHORTCUT,
+            static::OPTION_INPUT_STREAM_OPTIONS,
+            static::OPTION_INPUT_STREAM_OPTIONS_SHORTCUT,
             InputOption::VALUE_OPTIONAL,
-            static::OPTION_INPUT_OPTIONS_DESCRIPTION,
+            static::OPTION_INPUT_STREAM_OPTIONS_DESCRIPTION,
             static::DEFAULT_OPTIONS
         );
 
@@ -111,10 +111,10 @@ class ProcessConsole extends Console
         );
 
         $this->addOption(
-            static::OPTION_OUTPUT_OPTIONS,
-            static::OPTION_OUTPUT_OPTIONS_SHORTCUT,
+            static::OPTION_OUTPUT_STREAM_OPTIONS,
+            static::OPTION_OUTPUT_STREAM_OPTIONS_SHORTCUT,
             InputOption::VALUE_OPTIONAL,
-            static::OPTION_OUTPUT_OPTIONS_DESCRIPTION,
+            static::OPTION_OUTPUT_STREAM_OPTIONS_DESCRIPTION,
             static::DEFAULT_OPTIONS
         );
     }
@@ -244,7 +244,7 @@ class ProcessConsole extends Console
      */
     protected function getInputStreamOptions(InputInterface $input): array
     {
-        return $this->mapOptionToArray($input->getOption(static::OPTION_INPUT_OPTIONS));
+        return $this->mapOptionToArray($input->getOption(static::OPTION_INPUT_STREAM_OPTIONS));
     }
 
     /**
@@ -254,16 +254,16 @@ class ProcessConsole extends Console
      */
     protected function getOutputStreamOptions(InputInterface $input): array
     {
-        return $this->mapOptionToArray($input->getOption(static::OPTION_OUTPUT_OPTIONS));
+        return $this->mapOptionToArray($input->getOption(static::OPTION_OUTPUT_STREAM_OPTIONS));
     }
 
     /**
-     * @param string $option
+     * @param string $options
      *
      * @return array
      */
-    protected function mapOptionToArray(string $option): ?array
+    protected function mapOptionToArray(string $options): ?array
     {
-        return $this->getFactory()->getUtilEncodingService()->decodeJson($option, true);
+        return $this->getFactory()->getUtilEncodingService()->decodeJson($options, true);
     }
 }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Handler/StdErrStreamHandlerPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Handler/StdErrStreamHandlerPlugin.php
@@ -20,7 +20,7 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLogHandlerPlug
 class StdErrStreamHandlerPlugin extends AbstractPlugin implements MiddlewareLogHandlerPluginInterface
 {
     /**
-     * @var \Monolog\Handler\AbstractProcessingHandler
+     * @var \Monolog\Handler\AbstractProcessingHandler|null
      */
     protected $handler;
 

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Handler/StdErrStreamHandlerPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Handler/StdErrStreamHandlerPlugin.php
@@ -129,6 +129,8 @@ class StdErrStreamHandlerPlugin extends AbstractPlugin implements MiddlewareLogH
     }
 
     /**
+     * @api
+     *
      * @return void
      */
     public function close(): void

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Handler/StdErrStreamHandlerPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Handler/StdErrStreamHandlerPlugin.php
@@ -8,7 +8,7 @@
 namespace SprykerMiddleware\Zed\Process\Communication\Plugin\Handler;
 
 use Monolog\Formatter\FormatterInterface;
-use Monolog\Handler\AbstractHandler;
+use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Handler\HandlerInterface;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLogHandlerPluginInterface;
@@ -20,14 +20,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLogHandlerPlug
 class StdErrStreamHandlerPlugin extends AbstractPlugin implements MiddlewareLogHandlerPluginInterface
 {
     /**
-     * @var \Monolog\Handler\AbstractHandler
+     * @var \Monolog\Handler\AbstractProcessingHandler
      */
     protected $handler;
 
     /**
-     * @return \Monolog\Handler\AbstractHandler
+     * @return \Monolog\Handler\AbstractProcessingHandler
      */
-    protected function getHandler(): AbstractHandler
+    protected function getHandler(): AbstractProcessingHandler
     {
         if (!$this->handler) {
             $this->handler = $this->getFactory()->createStdErrStreamHandler();

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Handler/StdErrStreamHandlerPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Handler/StdErrStreamHandlerPlugin.php
@@ -127,4 +127,12 @@ class StdErrStreamHandlerPlugin extends AbstractPlugin implements MiddlewareLogH
     {
         return $this->getHandler()->setLevel($level);
     }
+
+    /**
+     * @return void
+     */
+    public function close(): void
+    {
+        $this->getHandler()->close();
+    }
 }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/AbstractOptionAwareStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/AbstractOptionAwareStreamPlugin.php
@@ -18,7 +18,7 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OptionAwareStreamPlug
 abstract class AbstractOptionAwareStreamPlugin extends AbstractPlugin implements OptionAwareStreamPluginInterface
 {
     /**
-     * @var array
+     * @var array|null
      */
     protected $options;
 

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/AbstractOptionAwareStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/AbstractOptionAwareStreamPlugin.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Communication\Plugin\Stream;
+
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OptionAwareStreamPluginInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @method \SprykerMiddleware\Zed\Process\Business\ProcessFacadeInterface getFacade()
+ * @method \SprykerMiddleware\Zed\Process\Communication\ProcessCommunicationFactory getFactory()
+ */
+abstract class AbstractOptionAwareStreamPlugin extends AbstractPlugin implements OptionAwareStreamPluginInterface
+{
+    protected const OPTION_TYPE_STRING = 'string';
+    protected const OPTION_TYPE_NULL = 'null';
+
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @api
+     *
+     * @param array $options
+     *
+     * @return $this
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $this->configureOptionsResolver()->resolve($options);
+
+        return $this;
+    }
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    protected function createOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    abstract protected function configureOptionsResolver(): OptionsResolver;
+}

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/AbstractOptionAwareStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/AbstractOptionAwareStreamPlugin.php
@@ -8,8 +8,8 @@
 namespace SprykerMiddleware\Zed\Process\Communication\Plugin\Stream;
 
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface;
 use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OptionAwareStreamPluginInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @method \SprykerMiddleware\Zed\Process\Business\ProcessFacadeInterface getFacade()
@@ -17,9 +17,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 abstract class AbstractOptionAwareStreamPlugin extends AbstractPlugin implements OptionAwareStreamPluginInterface
 {
-    protected const OPTION_TYPE_STRING = 'string';
-    protected const OPTION_TYPE_NULL = 'null';
-
     /**
      * @var array
      */
@@ -34,21 +31,13 @@ abstract class AbstractOptionAwareStreamPlugin extends AbstractPlugin implements
      */
     public function setOptions(array $options)
     {
-        $this->options = $this->configureOptionsResolver()->resolve($options);
+        $this->options = $this->getStreamConfigurator()->resolveOptions($options);
 
         return $this;
     }
 
     /**
-     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     * @return \SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface
      */
-    protected function createOptionsResolver(): OptionsResolver
-    {
-        return new OptionsResolver();
-    }
-
-    /**
-     * @return \Symfony\Component\OptionsResolver\OptionsResolver
-     */
-    abstract protected function configureOptionsResolver(): OptionsResolver;
+    abstract protected function getStreamConfigurator(): StreamConfiguratorInterface;
 }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/DirectoryInputStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/DirectoryInputStreamPlugin.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Communication\Plugin\Stream;
+
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use SprykerMiddleware\Shared\Process\Stream\ReadStreamInterface;
+use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface;
+
+/**
+ * @method \SprykerMiddleware\Zed\Process\Business\ProcessFacadeInterface getFacade()
+ * @method \SprykerMiddleware\Zed\Process\Communication\ProcessCommunicationFactory getFactory()
+ */
+class DirectoryInputStreamPlugin extends AbstractPlugin implements InputStreamPluginInterface
+{
+    protected const PLUGIN_NAME = 'DirectoryInputStreamPlugin';
+
+    /**
+     * @api
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::PLUGIN_NAME;
+    }
+
+    /**
+     * @api
+     *
+     * @param string $path
+     *
+     * @return \SprykerMiddleware\Shared\Process\Stream\ReadStreamInterface
+     */
+    public function getInputStream(string $path): ReadStreamInterface
+    {
+        return $this->getFactory()
+            ->createStreamFactory()
+            ->createDirectoryStream($path);
+    }
+}

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlInputStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlInputStreamPlugin.php
@@ -49,6 +49,10 @@ class XmlInputStreamPlugin extends AbstractOptionAwareStreamPlugin implements In
             );
     }
 
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
     protected function configureOptionsResolver(): OptionsResolver
     {
         return $this->createOptionsResolver()

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlInputStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlInputStreamPlugin.php
@@ -8,8 +8,9 @@
 namespace SprykerMiddleware\Zed\Process\Communication\Plugin\Stream;
 
 use SprykerMiddleware\Shared\Process\Stream\ReadStreamInterface;
+use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface;
+use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\XmlInputStreamConfigurator;
 use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @method \SprykerMiddleware\Zed\Process\Business\ProcessFacadeInterface getFacade()
@@ -18,8 +19,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class XmlInputStreamPlugin extends AbstractOptionAwareStreamPlugin implements InputStreamPluginInterface
 {
     protected const PLUGIN_NAME = 'XmlInputStreamPlugin';
-
-    protected const ROOT_NODE_NAME_STREAM_OPTION = 'rootNodeName';
 
     /**
      * @api
@@ -44,19 +43,16 @@ class XmlInputStreamPlugin extends AbstractOptionAwareStreamPlugin implements In
             ->createStreamFactory()
             ->createXmlReadStream(
                 $path,
-                $this->options[static::ROOT_NODE_NAME_STREAM_OPTION],
+                $this->options[XmlInputStreamConfigurator::ROOT_NODE_NAME_STREAM_OPTION],
                 $this->getFactory()->getDecoder()
             );
     }
 
-
     /**
-     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     * @return \SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface
      */
-    protected function configureOptionsResolver(): OptionsResolver
+    protected function getStreamConfigurator(): StreamConfiguratorInterface
     {
-        return $this->createOptionsResolver()
-            ->setRequired([static::ROOT_NODE_NAME_STREAM_OPTION])
-            ->setAllowedTypes(static::ROOT_NODE_NAME_STREAM_OPTION, [static::OPTION_TYPE_STRING]);
+        return $this->getFactory()->createXmlInputStreamConfigurator();
     }
 }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlInputStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlInputStreamPlugin.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Communication\Plugin\Stream;
+
+use SprykerMiddleware\Shared\Process\Stream\ReadStreamInterface;
+use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @method \SprykerMiddleware\Zed\Process\Business\ProcessFacadeInterface getFacade()
+ * @method \SprykerMiddleware\Zed\Process\Communication\ProcessCommunicationFactory getFactory()
+ */
+class XmlInputStreamPlugin extends AbstractOptionAwareStreamPlugin implements InputStreamPluginInterface
+{
+    protected const PLUGIN_NAME = 'XmlInputStreamPlugin';
+
+    protected const ROOT_NODE_NAME_STREAM_OPTION = 'rootNodeName';
+
+    /**
+     * @api
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::PLUGIN_NAME;
+    }
+
+    /**
+     * @api
+     *
+     * @param string $path
+     *
+     * @return \SprykerMiddleware\Shared\Process\Stream\ReadStreamInterface
+     */
+    public function getInputStream(string $path): ReadStreamInterface
+    {
+        return $this->getFactory()
+            ->createStreamFactory()
+            ->createXmlReadStream(
+                $path,
+                $this->options[static::ROOT_NODE_NAME_STREAM_OPTION],
+                $this->getFactory()->getDecoder()
+            );
+    }
+
+    protected function configureOptionsResolver(): OptionsResolver
+    {
+        return $this->createOptionsResolver()
+            ->setRequired([static::ROOT_NODE_NAME_STREAM_OPTION])
+            ->setAllowedTypes(static::ROOT_NODE_NAME_STREAM_OPTION, [static::OPTION_TYPE_STRING]);
+    }
+}

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlOutputStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlOutputStreamPlugin.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Communication\Plugin\Stream;
+
+use SprykerMiddleware\Shared\Process\Stream\WriteStreamInterface;
+use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @method \SprykerMiddleware\Zed\Process\Business\ProcessFacadeInterface getFacade()
+ * @method \SprykerMiddleware\Zed\Process\Communication\ProcessCommunicationFactory getFactory()
+ */
+class XmlOutputStreamPlugin extends AbstractOptionAwareStreamPlugin implements OutputStreamPluginInterface
+{
+    protected const PLUGIN_NAME = 'XmlOutputStreamPlugin';
+
+    protected const ROOT_NODE_NAME_STREAM_OPTION = 'rootNodeName';
+    protected const ENTITY_NODE_NAME_STREAM_OPTION = 'entityNodeName';
+    protected const VERSION_STREAM_OPTION = 'version';
+    protected const ENCODING_STREAM_OPTION = 'encoding';
+    protected const STANDALONE_STREAM_OPTION = 'standalone';
+
+    /**
+     * @api
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::PLUGIN_NAME;
+    }
+
+    /**
+     * @api
+     *
+     * @param string $path
+     *
+     * @return \SprykerMiddleware\Shared\Process\Stream\WriteStreamInterface
+     */
+    public function getOutputStream(string $path): WriteStreamInterface
+    {
+        return $this->getFactory()
+            ->createStreamFactory()
+            ->createXmlWriteStream(
+                $path,
+                $this->options[static::ROOT_NODE_NAME_STREAM_OPTION],
+                $this->options[static::ENTITY_NODE_NAME_STREAM_OPTION],
+                $this->getFactory()->getEncoder(),
+                $this->options[static::VERSION_STREAM_OPTION],
+                $this->options[static::ENCODING_STREAM_OPTION],
+                $this->options[static::STANDALONE_STREAM_OPTION]
+            );
+    }
+
+    protected function configureOptionsResolver(): OptionsResolver
+    {
+        return $this->createOptionsResolver()
+            ->setDefaults([
+                static::VERSION_STREAM_OPTION => null,
+                static::ENCODING_STREAM_OPTION => null,
+                static::STANDALONE_STREAM_OPTION => null,
+            ])
+            ->setRequired([static::ROOT_NODE_NAME_STREAM_OPTION, static::ENTITY_NODE_NAME_STREAM_OPTION])
+            ->setAllowedTypes(
+                static::ROOT_NODE_NAME_STREAM_OPTION, [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
+            ])
+            ->setAllowedTypes(
+            static::ENTITY_NODE_NAME_STREAM_OPTION, [
+                static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
+            ])
+            ->setAllowedTypes(
+                static::VERSION_STREAM_OPTION, [
+                static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
+            ])
+            ->setAllowedTypes(
+                static::ENCODING_STREAM_OPTION, [
+                static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
+            ])
+            ->setAllowedTypes(
+                static::STANDALONE_STREAM_OPTION, [
+                static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
+            ]);
+    }
+}

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlOutputStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlOutputStreamPlugin.php
@@ -8,8 +8,9 @@
 namespace SprykerMiddleware\Zed\Process\Communication\Plugin\Stream;
 
 use SprykerMiddleware\Shared\Process\Stream\WriteStreamInterface;
+use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface;
+use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\XmlOutputStreamConfigurator;
 use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @method \SprykerMiddleware\Zed\Process\Business\ProcessFacadeInterface getFacade()
@@ -18,12 +19,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class XmlOutputStreamPlugin extends AbstractOptionAwareStreamPlugin implements OutputStreamPluginInterface
 {
     protected const PLUGIN_NAME = 'XmlOutputStreamPlugin';
-
-    protected const ROOT_NODE_NAME_STREAM_OPTION = 'rootNodeName';
-    protected const ENTITY_NODE_NAME_STREAM_OPTION = 'entityNodeName';
-    protected const VERSION_STREAM_OPTION = 'version';
-    protected const ENCODING_STREAM_OPTION = 'encoding';
-    protected const STANDALONE_STREAM_OPTION = 'standalone';
 
     /**
      * @api
@@ -48,56 +43,20 @@ class XmlOutputStreamPlugin extends AbstractOptionAwareStreamPlugin implements O
             ->createStreamFactory()
             ->createXmlWriteStream(
                 $path,
-                $this->options[static::ROOT_NODE_NAME_STREAM_OPTION],
-                $this->options[static::ENTITY_NODE_NAME_STREAM_OPTION],
+                $this->options[XmlOutputStreamConfigurator::ROOT_NODE_NAME_STREAM_OPTION],
+                $this->options[XmlOutputStreamConfigurator::ENTITY_NODE_NAME_STREAM_OPTION],
                 $this->getFactory()->getEncoder(),
-                $this->options[static::VERSION_STREAM_OPTION],
-                $this->options[static::ENCODING_STREAM_OPTION],
-                $this->options[static::STANDALONE_STREAM_OPTION]
+                $this->options[XmlOutputStreamConfigurator::VERSION_STREAM_OPTION],
+                $this->options[XmlOutputStreamConfigurator::ENCODING_STREAM_OPTION],
+                $this->options[XmlOutputStreamConfigurator::STANDALONE_STREAM_OPTION]
             );
     }
 
     /**
-     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     * @return \SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface
      */
-    protected function configureOptionsResolver(): OptionsResolver
+    protected function getStreamConfigurator(): StreamConfiguratorInterface
     {
-        return $this->createOptionsResolver()
-            ->setDefaults([
-                static::VERSION_STREAM_OPTION => null,
-                static::ENCODING_STREAM_OPTION => null,
-                static::STANDALONE_STREAM_OPTION => null,
-            ])
-            ->setRequired([static::ROOT_NODE_NAME_STREAM_OPTION, static::ENTITY_NODE_NAME_STREAM_OPTION])
-            ->setAllowedTypes(
-                static::ROOT_NODE_NAME_STREAM_OPTION,
-                [
-                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
-                ]
-            )
-            ->setAllowedTypes(
-                static::ENTITY_NODE_NAME_STREAM_OPTION,
-                [
-                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
-                ]
-            )
-            ->setAllowedTypes(
-                static::VERSION_STREAM_OPTION,
-                [
-                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
-                ]
-            )
-            ->setAllowedTypes(
-                static::ENCODING_STREAM_OPTION,
-                [
-                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
-                ]
-            )
-            ->setAllowedTypes(
-                static::STANDALONE_STREAM_OPTION,
-                [
-                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
-                ]
-            );
+        return $this->getFactory()->createXmlOutputStreamConfigurator();
     }
 }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlOutputStreamPlugin.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/Stream/XmlOutputStreamPlugin.php
@@ -57,6 +57,9 @@ class XmlOutputStreamPlugin extends AbstractOptionAwareStreamPlugin implements O
             );
     }
 
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
     protected function configureOptionsResolver(): OptionsResolver
     {
         return $this->createOptionsResolver()
@@ -67,24 +70,34 @@ class XmlOutputStreamPlugin extends AbstractOptionAwareStreamPlugin implements O
             ])
             ->setRequired([static::ROOT_NODE_NAME_STREAM_OPTION, static::ENTITY_NODE_NAME_STREAM_OPTION])
             ->setAllowedTypes(
-                static::ROOT_NODE_NAME_STREAM_OPTION, [
-                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
-            ])
+                static::ROOT_NODE_NAME_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            )
             ->setAllowedTypes(
-            static::ENTITY_NODE_NAME_STREAM_OPTION, [
-                static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
-            ])
+                static::ENTITY_NODE_NAME_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            )
             ->setAllowedTypes(
-                static::VERSION_STREAM_OPTION, [
-                static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
-            ])
+                static::VERSION_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            )
             ->setAllowedTypes(
-                static::ENCODING_STREAM_OPTION, [
-                static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
-            ])
+                static::ENCODING_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            )
             ->setAllowedTypes(
-                static::STANDALONE_STREAM_OPTION, [
-                static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL
-            ]);
+                static::STANDALONE_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            );
     }
 }

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/StreamConfigurator/AbstractStreamConfigurator.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/StreamConfigurator/AbstractStreamConfigurator.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractStreamConfigurator implements StreamConfiguratorInterface
+{
+    protected const OPTION_TYPE_STRING = 'string';
+    protected const OPTION_TYPE_NULL = 'null';
+
+    /**
+     * @var \Symfony\Component\OptionsResolver\OptionsResolver $optionsResolver
+     */
+    protected $optionsResolver;
+
+    /**
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $optionsResolver
+     */
+    public function __construct(OptionsResolver $optionsResolver)
+    {
+        $this->optionsResolver = $optionsResolver;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    public function resolveOptions(array $options): array
+    {
+        return $this->configureOptionsResolver()->resolve($options);
+    }
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    abstract protected function configureOptionsResolver(): OptionsResolver;
+}

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/StreamConfigurator/StreamConfiguratorInterface.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/StreamConfigurator/StreamConfiguratorInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator;
+
+interface StreamConfiguratorInterface
+{
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    public function resolveOptions(array $options): array;
+}

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/StreamConfigurator/XmlInputStreamConfigurator.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/StreamConfigurator/XmlInputStreamConfigurator.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class XmlInputStreamConfigurator extends AbstractStreamConfigurator
+{
+    public const ROOT_NODE_NAME_STREAM_OPTION = 'rootNodeName';
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    protected function configureOptionsResolver(): OptionsResolver
+    {
+        return $this->optionsResolver
+            ->setRequired([static::ROOT_NODE_NAME_STREAM_OPTION])
+            ->setAllowedTypes(static::ROOT_NODE_NAME_STREAM_OPTION, [static::OPTION_TYPE_STRING]);
+    }
+}

--- a/src/SprykerMiddleware/Zed/Process/Communication/Plugin/StreamConfigurator/XmlOutputStreamConfigurator.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/Plugin/StreamConfigurator/XmlOutputStreamConfigurator.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class XmlOutputStreamConfigurator extends AbstractStreamConfigurator
+{
+    public const ROOT_NODE_NAME_STREAM_OPTION = 'rootNodeName';
+    public const ENTITY_NODE_NAME_STREAM_OPTION = 'entityNodeName';
+    public const VERSION_STREAM_OPTION = 'version';
+    public const ENCODING_STREAM_OPTION = 'encoding';
+    public const STANDALONE_STREAM_OPTION = 'standalone';
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    protected function configureOptionsResolver(): OptionsResolver
+    {
+        return $this->optionsResolver
+            ->setDefaults([
+                static::VERSION_STREAM_OPTION => null,
+                static::ENCODING_STREAM_OPTION => null,
+                static::STANDALONE_STREAM_OPTION => null,
+            ])
+            ->setRequired([
+                static::ROOT_NODE_NAME_STREAM_OPTION,
+                static::ENTITY_NODE_NAME_STREAM_OPTION,
+            ])
+            ->setAllowedTypes(
+                static::ROOT_NODE_NAME_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            )
+            ->setAllowedTypes(
+                static::ENTITY_NODE_NAME_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            )
+            ->setAllowedTypes(
+                static::VERSION_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            )
+            ->setAllowedTypes(
+                static::ENCODING_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            )
+            ->setAllowedTypes(
+                static::STANDALONE_STREAM_OPTION,
+                [
+                    static::OPTION_TYPE_STRING, static::OPTION_TYPE_NULL,
+                ]
+            );
+    }
+}

--- a/src/SprykerMiddleware/Zed/Process/Communication/ProcessCommunicationFactory.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/ProcessCommunicationFactory.php
@@ -9,7 +9,7 @@ namespace SprykerMiddleware\Zed\Process\Communication;
 
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LogstashFormatter;
-use Monolog\Handler\AbstractHandler;
+use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\IntrospectionProcessor;
@@ -103,9 +103,9 @@ class ProcessCommunicationFactory extends AbstractCommunicationFactory
     }
 
     /**
-     * @return \Monolog\Handler\AbstractHandler
+     * @return \Monolog\Handler\AbstractProcessingHandler
      */
-    public function createStdErrStreamHandler(): AbstractHandler
+    public function createStdErrStreamHandler(): AbstractProcessingHandler
     {
         $streamHandler = new StreamHandler(
             'php://stderr',

--- a/src/SprykerMiddleware/Zed/Process/Communication/ProcessCommunicationFactory.php
+++ b/src/SprykerMiddleware/Zed/Process/Communication/ProcessCommunicationFactory.php
@@ -23,9 +23,14 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\TranslatorFunctionFactoryInterface;
 use SprykerMiddleware\Zed\Process\Business\Validator\Factory\ValidatorFactory;
 use SprykerMiddleware\Zed\Process\Business\Validator\Factory\ValidatorFactoryInterface;
+use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface;
+use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\XmlInputStreamConfigurator;
+use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\XmlOutputStreamConfigurator;
 use SprykerMiddleware\Zed\Process\Dependency\External\ProcessToSymfonyDecoderAdapterInterface;
 use SprykerMiddleware\Zed\Process\Dependency\External\ProcessToSymfonyEncoderAdapterInterface;
+use SprykerMiddleware\Zed\Process\Dependency\Service\ProcessToUtilEncodingServiceInterface;
 use SprykerMiddleware\Zed\Process\ProcessDependencyProvider;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @method \SprykerMiddleware\Zed\Process\ProcessConfig getConfig()
@@ -158,5 +163,37 @@ class ProcessCommunicationFactory extends AbstractCommunicationFactory
     public function getEncoder(): ProcessToSymfonyEncoderAdapterInterface
     {
         return $this->getProvidedDependency(ProcessDependencyProvider::ENCODER);
+    }
+
+    /**
+     * @return \SprykerMiddleware\Zed\Process\Dependency\Service\ProcessToUtilEncodingServiceInterface
+     */
+    public function getUtilEncodingService(): ProcessToUtilEncodingServiceInterface
+    {
+        return $this->getProvidedDependency(ProcessDependencyProvider::SERVICE_UTIL_ENCODING);
+    }
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    public function createOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+
+    /**
+     * @return \SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface
+     */
+    public function createXmlInputStreamConfigurator(): StreamConfiguratorInterface
+    {
+        return new XmlInputStreamConfigurator($this->createOptionsResolver());
+    }
+
+    /**
+     * @return \SprykerMiddleware\Zed\Process\Communication\Plugin\StreamConfigurator\StreamConfiguratorInterface
+     */
+    public function createXmlOutputStreamConfigurator(): StreamConfiguratorInterface
+    {
+        return new XmlOutputStreamConfigurator($this->createOptionsResolver());
     }
 }

--- a/src/SprykerMiddleware/Zed/Process/Dependency/Plugin/Stream/OptionAwareStreamPluginInterface.php
+++ b/src/SprykerMiddleware/Zed/Process/Dependency/Plugin/Stream/OptionAwareStreamPluginInterface.php
@@ -7,9 +7,15 @@
 
 namespace SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream;
 
+/**
+ * Use this plugin if you need configurable options in input or output stream.
+ */
 interface OptionAwareStreamPluginInterface
 {
     /**
+     * Specification:
+     *  - Sets options to input/output stream.
+     *
      * @api
      *
      * @param array $options

--- a/src/SprykerMiddleware/Zed/Process/Dependency/Plugin/Stream/OptionAwareStreamPluginInterface.php
+++ b/src/SprykerMiddleware/Zed/Process/Dependency/Plugin/Stream/OptionAwareStreamPluginInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream;
+
+interface OptionAwareStreamPluginInterface
+{
+    /**
+     * @api
+     *
+     * @param array $options
+     *
+     * @return $this
+     */
+    public function setOptions(array $options);
+}

--- a/src/SprykerMiddleware/Zed/Process/ProcessDependencyProvider.php
+++ b/src/SprykerMiddleware/Zed/Process/ProcessDependencyProvider.php
@@ -92,6 +92,7 @@ class ProcessDependencyProvider extends AbstractBundleDependencyProvider
         $container = $this->addValidators($container);
         $container = $this->addDecoder($container);
         $container = $this->addEncoder($container);
+        $container = $this->addEncodingService($container);
 
         return $container;
     }

--- a/tooling.yml
+++ b/tooling.yml
@@ -1,0 +1,2 @@
+architecture-sniffer:
+    priority: 2


### PR DESCRIPTION
- Developer(s): @ostrizhny

- Ticket: https://spryker.atlassian.net/browse/SM-202

- Academy PR: -

- Release Group: https://release.spryker.com/release-groups/view/1541


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Process               | minor                 |                       |

#### Release Notes

Implemented middleware's stream plugins for middleware's streams which hadn't had such plugins before.

-----------------------------------------

#### Module Process

##### Change log

Improvements

* Introduced `SprykerMiddleware\Zed\Process\Communication\Plugin\Stream\AbstractOptionAwareStreamPlugin` for streams with require options except `$path`.
* Introduced `SprykerMiddleware\Zed\Process\Communication\Plugin\Stream\DirectoryInputStreamPlugin`.
* Introduced `SprykerMiddleware\Zed\Process\Communication\Plugin\Stream\XmlInputStreamPlugin`.
* Introduced `SprykerMiddleware\Zed\Process\Communication\Plugin\Stream\XmlOutputStreamPlugin`.
* Adjusted `SprykerMiddleware\Zed\Process\Business\Process\Processor` to make it works with option aware plugins.
* Adjusted `SprykerMiddleware\Zed\Process\Communication\Console\ProcessConsole`. Provided opportunity to pass options for input (`--input-stream-options`/`-t`) and output (`--output-stream-options`/`-u`) streams options. These options as argument receive json eg: `'{"rootNodeName": "Root", "entityNodeName": "Entity"}'`.
* Added `monolog/monolog` dependency.
* Increased `php` version dependency to `>=7.2`

