### PR TITLE
SM-215: Change dependency to spryker monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "license": "proprietary",
     "minimum-stability": "dev",
     "require": {
-        "monolog/monolog": "^2.0.0",
         "php": ">=7.2",
         "spryker/console": "^4.0.0",
         "spryker/development": "^3.0.0",
+        "spryker/monolog": "^2.0.0",
         "spryker/symfony": "^3.0.0",
         "spryker/transfer": "^3.4.0",
         "spryker/util-encoding": "^2.0.0",


### PR DESCRIPTION
- Developer(s): @artem-png 

- Ticket: https://spryker.atlassian.net/browse/SM-215

- Academy PR: -

- Release Group: https://release.spryker.com/release-groups/view/2591


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Process               | minor                 |                       |

-----------------------------------------

#### Module Process

##### Change log

Improvements

- Adjusted dependency `monolog/monolog` to be provided via `spryker/monolog` meta-package.
This allows to use also Monolog v1 instead of only v2.
